### PR TITLE
Removed redundant read of NBT data

### DIFF
--- a/src/main/java/gregtech/api/metatileentity/BaseMetaPipeEntity.java
+++ b/src/main/java/gregtech/api/metatileentity/BaseMetaPipeEntity.java
@@ -192,8 +192,8 @@ public class BaseMetaPipeEntity extends BaseTileEntity implements IGregTechTileE
 
             // check old form of data
             mCoverData = new ISerializableObject[6];
-            if (aNBT.hasKey("mCoverData", 11) && aNBT.getIntArray("mCoverData").length == 6) {
-                int[] tOldData = aNBT.getIntArray("mCoverData");
+            int[] tOldData = aNBT.getIntArray("mCoverData");
+            if (aNBT.hasKey("mCoverData", 11) && tOldData.length == 6) {
                 for (int i = 0; i < tOldData.length; i++) {
                     if(mCoverBehaviors[i] instanceof GT_Cover_Fluidfilter) {
                         final String filterKey = String.format("fluidFilter%d", i);

--- a/src/main/java/gregtech/api/metatileentity/BaseMetaTileEntity.java
+++ b/src/main/java/gregtech/api/metatileentity/BaseMetaTileEntity.java
@@ -249,8 +249,8 @@ public class BaseMetaTileEntity extends BaseTileEntity implements IGregTechTileE
 
             // check legacy data
             mCoverData = new ISerializableObject[6];
-            if (aNBT.hasKey("mCoverData", 11) && aNBT.getIntArray("mCoverData").length == 6) {
-                int[] tOldData = aNBT.getIntArray("mCoverData");
+            int[] tOldData = aNBT.getIntArray("mCoverData");
+            if (aNBT.hasKey("mCoverData", 11) && tOldData.length == 6) {
                 for (int i = 0; i < tOldData.length; i++) {
                     if (mCoverBehaviors[i] != null)
                         mCoverData[i] = mCoverBehaviors[i].createDataObject(tOldData[i]);


### PR DESCRIPTION
There was a redundant nbt read in the cover logic for MTEs